### PR TITLE
zephyr: boards: thingy91_nrf9160: Enable size optimizations

### DIFF
--- a/boot/zephyr/boards/thingy91_nrf9160.conf
+++ b/boot/zephyr/boards/thingy91_nrf9160.conf
@@ -1,3 +1,6 @@
+# General
+CONFIG_SIZE_OPTIMIZATIONS=y
+
 # Disable Zephyr console
 CONFIG_CONSOLE=n
 CONFIG_CONSOLE_HANDLER=n


### PR DESCRIPTION
Size optimizations need to be enabled to avoid flash overflow.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>