### PR TITLE
[nrf noup] PM: adapted PM related code to CONFIG_SINGLE_APPLICATION_SLOT

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -7,7 +7,7 @@
 #include <pm_config.h>
 #include <mcuboot_config/mcuboot_config.h>
 
-#ifndef CONFIG_SINGLE_IMAGE_DFU
+#ifndef CONFIG_SINGLE_APPLICATION_SLOT
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)
 
@@ -34,7 +34,7 @@ extern uint32_t _image_1_primary_slot_id[];
 #endif
 #define FLASH_AREA_IMAGE_SCRATCH    PM_MCUBOOT_SCRATCH_ID
 
-#else /* CONFIG_SINGLE_IMAGE_DFU */
+#else /* CONFIG_SINGLE_APPLICATION_SLOT */
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)	PM_MCUBOOT_PRIMARY_ID
 #define FLASH_AREA_IMAGE_SECONDARY(x)	PM_MCUBOOT_PRIMARY_ID
@@ -44,7 +44,7 @@ extern uint32_t _image_1_primary_slot_id[];
  */
 #define FLASH_AREA_IMAGE_SCRATCH       0
 
-#endif /* CONFIG_SINGLE_IMAGE_DFU */
+#endif /* CONFIG_SINGLE_APPLICATION_SLOT */
 
 #else
 

--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -19,7 +19,7 @@ mcuboot_secondary:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
     after: mcuboot_primary
 
-#if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_IMAGE_DFU)
+#if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_scratch:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SCRATCH
   placement:


### PR DESCRIPTION
CONFIG_SINGLE_APPLICATION_SLOT replaced CONFIG_SINGLE_IMAGE_DFU
in the upstream, so need to adapt all the code which is using that
keyword.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>