### PR TITLE
[nrf fromlist] zephyr: use minimal CBPRINTF implementation

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -34,3 +34,5 @@ CONFIG_FPROTECT=y
 CONFIG_LOG=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
+CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
Addition of cbprintf capability in zephyr
zephyrproject-rtos/zephyr#29876
cause flash footprint rise by ~5 KB. Selecting
CBPRINTF_NANO=y mitigates the footprint rise to ~1 KB

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>